### PR TITLE
feat: Implement OS-specific autocrlf in Git config

### DIFF
--- a/home/private_dot_config/private_git/private_config.tmpl
+++ b/home/private_dot_config/private_git/private_config.tmpl
@@ -11,8 +11,13 @@
 # Handle line endings properly.
 # Ref. https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings
 [core]
-	autocrlf = input # macOS + Linux
-	# autocrlf = true # Windows
+{{- if or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux") }}
+	autocrlf = input # macOS & Linux
+{{- else if eq .chezmoi.os "windows" }}
+	autocrlf = true # Windows
+{{- else }}
+	autocrlf = input
+{{- end }}
 
 # Use VS Code as Git editor, diff tool and merge tool.
 # Ref. https://code.visualstudio.com/docs/sourcecontrol/overview#_vs-code-as-git-editor


### PR DESCRIPTION
Refactor the `autocrlf` setting in the Git core configuration to dynamically adapt based on the operating system. This leverages chezmoi's templating capabilities to ensure correct line ending handling across macOS, Linux, and Windows.

- Uses `autocrlf = input` for macOS and Linux.
- Uses `autocrlf = true` for Windows.
- Adds a fallback to `input` for other unsupported operating systems.