### PR TITLE
feat(brewfile): Add essential development and utility packages

### DIFF
--- a/home/.chezmoiscripts/darwin/run_once_before_install-packages-darwin.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_once_before_install-packages-darwin.sh.tmpl
@@ -18,11 +18,13 @@ brew bundle --file=/dev/stdin <<'BUNDLED_PACKAGES_EOF'
 # Brew Formulae (CLI Apps)
 brew "bash" # Latest Bash version.
 brew "bat" # Clone of cat with syntax highlighting and Git integration.
+brew "chezmoi" # Manage your dotfiles across multiple diverse machines, securely.
 brew "eza" # Modern, maintained replacement for ls.
 brew "fd" # Simple, fast and user-friendly alternative to find.
 brew "fdupes" # Identify or delete duplicate files.
 brew "ffmpeg" # Play, record, convert, and stream audio and video.
 brew "fzf" # Command-line fuzzy finder.
+brew "gemini-cli" # Interact with Google Gemini AI models from the command-line.
 brew "gh" # GitHub command-line tool.
 brew "git" # Latest Git version.
 brew "grep" # Latest Grep version (GNU grep, egrep and fgrep).
@@ -46,6 +48,7 @@ cask "colour-contrast-analyser" # Colour contrast checker.
 cask "cyberduck" # Server and cloud storage browser.
 cask "deepl" # Trains AIs to understand and translate texts.
 cask "discord" # Voice and text chat software.
+cask "fastmail" # Email client.
 cask "figma" # Collaborative team software.
 cask "firefox" # Web browser.
 cask "font-asap"
@@ -73,11 +76,12 @@ cask "keka" # File archiver.
 cask "kekaexternalhelper" # Helper application for the Keka file archiver.
 cask "logi-options+" # Software for Logitech devices.
 cask "maccy" # Clipboard manager.
-cask "nordvpn" # VPN client for secure internet access and private Browse.
 cask "notion" # App to write, plan, collaborate, and get organised.
+cask "obsidian" # Knowledge base that works on top of a local folder of plain text Markdown files.
 cask "pika" # Colour picker for colours onscreen.
 cask "safari-technology-preview" # Web browser.
 cask "slack" # Team communication and collaboration software.
+cask "surfshark" # VPN client for secure internet access and private browsing.
 cask "visual-studio-code" # Open-source code editor.
 cask "vlc" # Multimedia player.
 


### PR DESCRIPTION
Adds new formulae and casks for improved productivity and setup completeness on macOS:

Formulae:
- `chezmoi`: Ensures chezmoi is installed early for reliable dotfile management.
- `gemini-cli`: Command-line tool for interacting with Google's Gemini models.

Casks:
- `fastmail`: Adds the Fastmail desktop email client.
- `obsidian`: Includes the popular Markdown knowledge base application.
- VPN switch: Replaces NordVPN with Surfshark, and removes NordVPN cask.